### PR TITLE
required param function, make overlay close button a little smaller

### DIFF
--- a/src/Overlay.js
+++ b/src/Overlay.js
@@ -36,9 +36,9 @@ const cssOverlayName = css({
 const cssClose = css({
   label: "close",
   ...mixins.buttonReset,
-  width: 30,
-  height: 30,
-  fontSize: 16,
+  width: 26,
+  height: 26,
+  fontSize: 11,
   textAlign: "center",
   margin: 10,
   background: "rgba(255, 255, 255, 0.5)",

--- a/src/index.js
+++ b/src/index.js
@@ -8,11 +8,18 @@ const context = {
   api: null
 };
 
+function requiredParam(argName) {
+  console.error(`${argName} is required`);
+}
+
 export function init({ api }) {
   context.api = api;
 }
 
-export function renderMap(element, options) {
+export function renderMap(
+  element = requiredParam("element"),
+  options = requiredParam("options")
+) {
   render(<Map api={context.api} {...options} />, element);
 }
 


### PR DESCRIPTION
required param function, make overlay close button a little smaller to better match design

* Regarding the `requiredParam` function: Yah, it's crude, and only asserts 'something' was passed. I figured we'd do type checking and such in `Map.js`.... And also realized we shouldn't `throw` as that would 'stop the show' and break client sites. 