### PR TITLE
WS-7 Disable touch zooming for all IE browsers.

### DIFF
--- a/src/Map.js
+++ b/src/Map.js
@@ -18,6 +18,10 @@ import { asyncClientCall } from "./util";
 
 const ZOOM_FACTOR = 0.5;
 const ZOOM_DURATION = 250;
+const isIE =
+  window.navigator.userAgent.indexOf("MSIE ") !== -1 ||
+  window.navigator.userAgent.indexOf("Trident/") !== -1 ||
+  window.navigator.userAgent.indexOf("Edge/") !== -1;
 
 const cssMapContainer = css({
   label: "map-container",
@@ -35,6 +39,10 @@ const cssMap = css({
   borderRadius: "inherit",
   display: "block",
   overflow: "hidden"
+});
+
+const cssNoTouchZoom = css({
+  touchAction: "none"
 });
 
 export default class Map extends Component {
@@ -347,7 +355,11 @@ export default class Map extends Component {
     } = this.props;
     return (
       <div
-        className={cx(cssMapContainer, "meridian-map-container")}
+        className={cx(
+          cssMapContainer,
+          isIE && cssNoTouchZoom,
+          "meridian-map-container"
+        )}
         style={{ width, height }}
       >
         <Watermark />

--- a/src/Placemark.js
+++ b/src/Placemark.js
@@ -106,11 +106,14 @@ const Placemark = ({
       <button
         disabled={disabled}
         className={cx(cssPlacemarkIcon, "meridian-placemark-icon")}
+        style={getIconStyle(data)}
         onClick={event => {
           event.target.focus();
           onClick(event);
         }}
-        style={getIconStyle(data)}
+        onMouseDown={event => {
+          event.stopPropagation();
+        }}
       />
       <div
         className={cx(cssLabel, "meridian-label")}

--- a/src/Tag.js
+++ b/src/Tag.js
@@ -59,11 +59,14 @@ const Tag = ({
     <button
       disabled={disabled}
       className={className}
+      style={style}
       onClick={event => {
         event.target.focus();
         onClick(event);
       }}
-      style={style}
+      onMouseDown={event => {
+        event.stopPropagation();
+      }}
     />
   );
 };


### PR DESCRIPTION
This also includes a fix to disable panning when clicking on a mapMarker. This makes is much easier to click the markers.