### PR TITLE
Add ESLint spaced-comment rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -16,7 +16,16 @@ module.exports = {
   plugins: ["react", "@typescript-eslint"],
   rules: {
     curly: "error",
-    "spaced-comment": ["error", "always", { markers: ["/"] }],
+    "spaced-comment": [
+      "error",
+      "always",
+      {
+        // Cypress uses `///` comments to load TS types
+        markers: ["/"],
+        // webpack uses `/*!` comments for license blocks
+        exceptions: ["!"]
+      }
+    ],
     "consistent-return": "error",
     "no-unused-vars": "error",
     "no-console": "warn",

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -16,6 +16,7 @@ module.exports = {
   plugins: ["react", "@typescript-eslint"],
   rules: {
     curly: "error",
+    "spaced-comment": ["error", "always", { markers: ["/"] }],
     "consistent-return": "error",
     "no-unused-vars": "error",
     "no-console": "warn",

--- a/bin/test.sh
+++ b/bin/test.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 set -eu
 
-npx eslint "src/**/*.js"
-npx prettier --check "src/**/*.js"
+npx eslint "{src,cypress}/**/*.js"
+npx prettier --check "{src,cypress}/**/*.js"


### PR DESCRIPTION
- [x] This change is documented in CHANGELOG.md

This enforces spaced comments in JS, which are easier to read in my opinion.

Also I realized ESLint and Prettier weren't running on our Cypress files in Travis CI.

### Dev Note

`Cmd-Shift-P`

`Open Settings JSON`

Then add this block to enable ESLint auto fix on save:

```
  "editor.codeActionsOnSave": {
    "source.fixAll": true
  },
```