### PR TITLE
MR-665 fixes unpublished floors showing up in the tag list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Unpublished floors are now hidden from the floor selector
-- A bug where placemarks wouldn't update after changing floors
-- A bug where `loadPlacemarks` didn't work correctly
-
+- Unpublished floors are now hidden from the floor selector and tags list
+- Placemarks wouldn't update after changing floors
+- `loadPlacemarks` didn't work correctly
 
 ## [0.8.1] - 2020-09-09
 

--- a/src/TagListOverlay.js
+++ b/src/TagListOverlay.js
@@ -120,6 +120,7 @@ class TagListOverlay extends Component {
 
   renderTagList() {
     const {
+      floors,
       updateMap,
       tagOptions,
       tags,
@@ -136,18 +137,30 @@ class TagListOverlay extends Component {
       );
     }
     const match = createSearchMatcher(searchFilter);
+    const floorsByID = groupBy(floors, floor => floor.id);
     const processedTags = tags
-      .filter(
-        tag =>
+      // Remove tags from unpublished floors
+      .filter(tag => {
+        const floor = floorsByID[tag.map_id][0];
+        if (floor) {
+          return floor.published;
+        }
+        return true;
+      })
+      // Remove tags that don't match the local search terms
+      .filter(tag => {
+        return (
           match(tag.name) || match(tag.mac) || getTagLabels(tag).some(match)
-      )
-      // TODO: Should we show hidden tags?
+        );
+      })
+      // Remove control tags unless the developer wants them
       .filter(tag => {
         if (tagOptions.showControlTags !== true) {
           return !tag.is_control_tag;
         }
         return true;
       })
+      // Sort by name
       .sort((a, b) => {
         if (a.name < b.name) {
           return -1;


### PR DESCRIPTION
- [x] This change is documented in CHANGELOG.md

I tested this via modifying the API response inside `getFloors()` in Map.js

```ts
      results.find(floor => floor.id === "5757334940811264").published = false;
```
