### PR TITLE
Mrc 3287 web sdk keyword search not working

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.24.0] - 2025-12-08
+
+- MRC-3287 Web SDK keyword search not working
+
 ## [1.23.2] - 2025-12-03
 
 ### Fixed vulnerability
 
-- MRC-3282 [FE] Fix vulnerabilities issue identified in the web SDK dependencies
+- MRC-3282 Fix vulnerabilities issue identified in the web SDK dependencies
 
 ## [1.23.1] - 2025-04-08
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@meridian/web-sdk",
   "private": false,
-  "version": "1.23.2",
+  "version": "1.24.0",
   "description": "Web SDK for showing Aruba Meridian maps, tags, and more",
   "main": "./dist/web-sdk.js",
   "types": "./dist/src/web-sdk.d.ts",

--- a/src/AssetListOverlay.tsx
+++ b/src/AssetListOverlay.tsx
@@ -343,15 +343,35 @@ function PlacemarkResults(props: PlacemarkResultsProps) {
       if (placemark.type === "exclusion_area") {
         return false;
       }
+       console.log("placemarks", placemarks);
       if (placemarkOptions.showHiddenPlacemarks !== true) {
         return !placemark.hide_on_map;
       }
       return true;
     })
-    // Remove placemarks that don't match the local search terms
-    .filter((placemark: PlacemarkData) => {
-      return match(placemark.name || "") || match(placemark.type_name || "");
-    })
+// Remove placemarks that don't match the local search terms
+.filter((placemark: PlacemarkData) => {
+  const s = (v: any) =>
+    v === null || v === undefined ? "" : String(v);
+
+  return (
+    match(s(placemark.name)) ||
+    match(s(placemark.type_name)) ||
+    match(s(placemark.keywords)) ||
+    match(s(placemark.x)) ||
+    match(s(placemark.y)) ||
+    match(s(placemark.map)) ||
+    match(s(placemark.type_category)) ||
+    match(s(placemark.custom_1)) ||
+    match(s(placemark.custom_2)) ||
+    match(s(placemark.custom_3)) ||
+    match(s(placemark.custom_4)) ||
+    match(s(placemark.id)) ||
+    match(s(placemark.description))
+  );
+})
+
+
     // Sort by name
     .sort((a: PlacemarkData, b: PlacemarkData) => {
       if (a.name < b.name) {

--- a/src/AssetListOverlay.tsx
+++ b/src/AssetListOverlay.tsx
@@ -343,7 +343,6 @@ function PlacemarkResults(props: PlacemarkResultsProps) {
       if (placemark.type === "exclusion_area") {
         return false;
       }
-       console.log("placemarks", placemarks);
       if (placemarkOptions.showHiddenPlacemarks !== true) {
         return !placemark.hide_on_map;
       }

--- a/src/AssetListOverlay.tsx
+++ b/src/AssetListOverlay.tsx
@@ -348,6 +348,7 @@ function PlacemarkResults(props: PlacemarkResultsProps) {
       }
       return true;
     })
+    
 // Remove placemarks that don't match the local search terms
 .filter((placemark: PlacemarkData) => {
   const toSafeString = (value: any) =>
@@ -356,6 +357,7 @@ function PlacemarkResults(props: PlacemarkResultsProps) {
   return (
     match(toSafeString(placemark.name)) ||
     match(toSafeString(placemark.type_name)) ||
+    match(toSafeString(placemark.type)) ||
     match(toSafeString(placemark.keywords)) ||
     match(toSafeString(placemark.x)) ||
     match(toSafeString(placemark.y)) ||

--- a/src/AssetListOverlay.tsx
+++ b/src/AssetListOverlay.tsx
@@ -368,6 +368,7 @@ function PlacemarkResults(props: PlacemarkResultsProps) {
     match(toSafeString(placemark.custom_3)) ||
     match(toSafeString(placemark.custom_4)) ||
     match(toSafeString(placemark.id)) ||
+    match(toSafeString(placemark.color)) ||
     match(toSafeString(placemark.description))
   );
 })

--- a/src/AssetListOverlay.tsx
+++ b/src/AssetListOverlay.tsx
@@ -350,23 +350,23 @@ function PlacemarkResults(props: PlacemarkResultsProps) {
     })
 // Remove placemarks that don't match the local search terms
 .filter((placemark: PlacemarkData) => {
-  const s = (v: any) =>
-    v === null || v === undefined ? "" : String(v);
+  const toSafeString = (value: any) =>
+    value === null || value === undefined ? "" : String(value);
 
   return (
-    match(s(placemark.name)) ||
-    match(s(placemark.type_name)) ||
-    match(s(placemark.keywords)) ||
-    match(s(placemark.x)) ||
-    match(s(placemark.y)) ||
-    match(s(placemark.map)) ||
-    match(s(placemark.type_category)) ||
-    match(s(placemark.custom_1)) ||
-    match(s(placemark.custom_2)) ||
-    match(s(placemark.custom_3)) ||
-    match(s(placemark.custom_4)) ||
-    match(s(placemark.id)) ||
-    match(s(placemark.description))
+    match(toSafeString(placemark.name)) ||
+    match(toSafeString(placemark.type_name)) ||
+    match(toSafeString(placemark.keywords)) ||
+    match(toSafeString(placemark.x)) ||
+    match(toSafeString(placemark.y)) ||
+    match(toSafeString(placemark.map)) ||
+    match(toSafeString(placemark.type_category)) ||
+    match(toSafeString(placemark.custom_1)) ||
+    match(toSafeString(placemark.custom_2)) ||
+    match(toSafeString(placemark.custom_3)) ||
+    match(toSafeString(placemark.custom_4)) ||
+    match(toSafeString(placemark.id)) ||
+    match(toSafeString(placemark.description))
   );
 })
 


### PR DESCRIPTION
**Issue**
Searching keywords related data  was not returning expected placemarks.

**Root Cause**
Search keys in the Web SDK were limited and did not include other available placemark fields.

**Fix**
Added additional fields ( map, id, custom_1–4, id, keywords, x, y, type. type_category, description, color) to the search keys.

**Files Changed**
src/AssetListOverlay.tsx
pacakge.json
changelog.md

<img width="568" height="430" alt="image" src="https://github.com/user-attachments/assets/aed38cd9-7766-4a00-b188-222de77d24fb" />
